### PR TITLE
allow obs.get to also function as a setter (more mutanty!)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const nest = require('depnest')
 const { Value, computed } = require('mutant')
 const get = require('lodash.get')
+const set = require('lodash.set')
 const merge = require('lodash.merge')
 
 const STORAGE_KEY = 'patchSettings'
@@ -38,7 +39,16 @@ const create = (api) => {
     _initialise()
     if (!path) return _settings
 
-    return computed(_settings, s => get(s, path, fallback))
+    var obs = computed(_settings, s => get(s, path, fallback))
+    obs.set = function (value) {
+      if (value !== obs()) {
+        var updatedSettings = merge({}, _settings())
+        set(updatedSettings, path, value)
+        _settings.set(updatedSettings)
+      }
+    }
+
+    return obs
   }
 
   function _initialise () {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "depnest": "^1.3.0",
     "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.0",
+    "lodash.set": "^4.3.2",
     "mutant": "^3.21.2"
   }
 }


### PR DESCRIPTION
I've been noticing a pattern in https://github.com/ssbc/patchwork/blob/master/modules/page/html/render/settings.js that getting a property and assigning it to an `input` is easy, but then setting it `onChange` requires a bunch of extra code and targeting the setting that you want.

This PR allows you to get a reference to a setting using `settings.obs.get` and then also set it using the the same reference.

Now you can do this:

```js
var language = api.settings.obs.get('app.language')
return h('select', {
  value: language,
  'ev-change': (ev) => language.set(ev.target.value)
}, opts)
```

Much more mutanty! It would also make it much easier to create reusable settings widgets!

@mixmix 