### PR TITLE
settings.obs.get: use deepEqual for comparer

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const { Value, computed } = require('mutant')
 const get = require('lodash.get')
 const set = require('lodash.set')
 const merge = require('lodash.merge')
+const deepEqual = require('deep-equal')
 
 const STORAGE_KEY = 'patchSettings'
 
@@ -39,7 +40,7 @@ const create = (api) => {
     _initialise()
     if (!path) return _settings
 
-    var obs = computed(_settings, s => get(s, path, fallback))
+    var obs = computed(_settings, s => get(s, path, fallback), {comparer: deepEqual})
     obs.set = function (value) {
       if (value !== obs()) {
         var updatedSettings = merge({}, _settings())

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/mixmix/patch-settings#readme",
   "dependencies": {
+    "deep-equal": "^1.0.1",
     "depnest": "^1.3.0",
     "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.0",


### PR DESCRIPTION
This PR debounces changes using `deepEqual` to make sure that there actually was a change (before notifying your feed to refresh for no reason just because another setting changed).

Applies when you are watching settings that are not just value types.

Gonna merge this!