### PR TITLE
change setSync to use mergeWith

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ api.settings.sync.get('colors.secondary', 'white')
 
 `(newSettings=object)`
 
-Uses [lodash/merge](https://lodash.com/docs/4.17.4#get) to recurssively merge newSettings into settings.
+Uses [lodash.mergewith](https://lodash.com/docs/4.17.5#mergeWith) to recurssively merge newSettings into settings.
+Note if the value being merged is an Array, this merge is set to _overwrite_ the current value (this is necessary otherwise merging short Arrays in leaves vestigal settings from previous long Arrays).
 
 Example:
 ```js

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const nest = require('depnest')
 const { Value, computed } = require('mutant')
 const get = require('lodash.get')
 const set = require('lodash.set')
-const merge = require('lodash.merge')
+const mergeWith= require('lodash.mergewith')
 const deepEqual = require('deep-equal')
 
 const STORAGE_KEY = 'patchSettings'
@@ -32,7 +32,11 @@ const create = (api) => {
   function setSync (newSettings) {
     _initialise()
 
-    const updatedSettings = merge({}, _settings(), newSettings)
+    const updatedSettings = mergeWith({}, _settings(), newSettings, (objVal, srcVal) => {
+      if (Array.isArray(srcVal)) {
+        return srcVal
+      }
+    })
     _settings.set(updatedSettings)
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "patch-settings",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -336,6 +336,11 @@
         "ms": "2.0.0"
       }
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
     "depnest": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/depnest/-/depnest-1.3.0.tgz",
@@ -455,6 +460,16 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
       "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
+    },
+    "lodash.mergewith": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "loose-envify": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "depnest": "^1.3.0",
     "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.0",
+    "lodash.mergewith": "^4.6.1",
     "lodash.set": "^4.3.2",
     "mutant": "^3.21.2"
   }


### PR DESCRIPTION
This solves the case where you're trying to update your settings from a long array to a shorter array

e.g. 

```js
// old setting
['/public', '/inbox', '/notifications', '/settings']

// new setting
['/chess', '#mmt']
```

a classic merge will result with

```js
['/chess', '#mmt', '/notifications', '/settings']
```

which is infuriating!!!!!

Solved with mergeWith where we over-ride the merge in the case of Arrays